### PR TITLE
Add option to change autocast_adapter_dtype

### DIFF
--- a/method_comparison/MetaMathQA/default_training_params.json
+++ b/method_comparison/MetaMathQA/default_training_params.json
@@ -15,6 +15,7 @@
   },
   "lr_scheduler": "cosine",
   "use_amp": false,
+  "autocast_adapter_dtype": true,
   "attn_implementation": null,
   "generation_kwargs": {
     "max_length": 800,

--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -368,6 +368,7 @@ def main(*, path_experiment: str, experiment_name: str, clean: bool) -> None:
         compile=train_config.compile,
         attn_implementation=train_config.attn_implementation,
         peft_config=peft_config,
+        autocast_adapter_dtype=train_config.autocast_adapter_dtype,
     )
     print_verbose(model)
     num_trainable_params, num_params = model.get_nb_trainable_parameters()

--- a/method_comparison/MetaMathQA/utils.py
+++ b/method_comparison/MetaMathQA/utils.py
@@ -79,6 +79,7 @@ class TrainConfig:
         optimizer_kwargs: The optimizer keyword arguments (lr etc.)
         lr_scheduler: The learning rate scheduler (currently only None or 'cosine' are supported)
         use_amp: Whether to use automatic mixed precision
+        autocast_adapter_dtype: Whether to cast adapter dtype to float32, same argument as in PEFT
         generation_kwargs: Arguments passed to transformers GenerationConfig (used in evaluation)
         attn_implementation: The attention implementation to use (if any), see transformers docs
     """
@@ -97,6 +98,7 @@ class TrainConfig:
     optimizer_kwargs: dict[str, Any]
     lr_scheduler: Optional[Literal["cosine"]]
     use_amp: bool
+    autocast_adapter_dtype: bool
     generation_kwargs: dict[str, Any]
     attn_implementation: Optional[str]
 
@@ -235,11 +237,12 @@ def get_model(
     compile: bool,
     attn_implementation: Optional[str],
     peft_config: PeftConfig,
+    autocast_adapter_dtype: bool,
 ) -> nn.Module:
     base_model = get_base_model(
         model_id=model_id, dtype=dtype, compile=compile, attn_implementation=attn_implementation
     )
-    model = get_peft_model(base_model, peft_config)
+    model = get_peft_model(base_model, peft_config, autocast_adapter_dtype=autocast_adapter_dtype)
     return model
 
 


### PR DESCRIPTION
It's true by default, same as in PEFT in general.