### PR TITLE
docs(oft): fix typos in OFTConfig docstring (paramters, speficy)

### DIFF
--- a/src/peft/tuners/oft/config.py
+++ b/src/peft/tuners/oft/config.py
@@ -32,14 +32,14 @@ class OFTConfig(PeftConfig):
     Args:
         r (`int`):
             OFT rank, number of OFT blocks per injected layer. Bigger `r` results in more sparse update matrices with
-            fewer trainable paramters. You can only specify either `r` or `oft_block_size`, but not both
-            simultaneously, because `r` × `oft_block_size` = layer dimension. For simplicity, we let you speficy either
+            fewer trainable parameters. You can only specify either `r` or `oft_block_size`, but not both
+            simultaneously, because `r` × `oft_block_size` = layer dimension. For simplicity, we let you specify either
             `r` or `oft_block_size` and infer the other one. Default set to `r = 0`, the user is advised to set the
             `oft_block_size` instead for better clarity.
         oft_block_size (`int`): OFT block size across different layers. Bigger `oft_block_size` results in more dense
             update matrices with more trainable parameters. Choose `oft_block_size` to be divisible by layer's input
             dimension (`in_features`), e.g., 4, 8, 16. You can only specify either `r` or `oft_block_size`, but not
-            both simultaneously, because `r` × `oft_block_size` = layer dimension. For simplicity, we let you speficy
+            both simultaneously, because `r` × `oft_block_size` = layer dimension. For simplicity, we let you specify
             either `r` or `oft_block_size` and infer the other one. Default set to `oft_block_size = 32`.
         use_cayley_neumann (bool): Specifies whether to use the Cayley-Neumann parameterization (efficient but
             approximate) or the vanilla Cayley parameterization (exact but computationally expensive because of matrix


### PR DESCRIPTION
## What does this PR do?

Per [@BenjaminBossan's request on huggingface/peft#3311](https://github.com/huggingface/peft/pull/3311#issuecomment-4640331756), re-targeting the OFT typo fixes against this doc-restructure branch (#3300 against `huggingface/peft:main`).

Your restructure moves the contents of `docs/source/conceptual_guides/oft.md` into the `OFTConfig` docstring in `src/peft/tuners/oft/config.py`, and the same three character-level typos got carried along. This PR fixes them in their new home:

- `paramters` → `parameters` (line 35)
- `speficy` → `specify` (line 36)
- `speficy` → `specify` (line 42)

Pure docstring, three character-level corrections. Closes huggingface/peft#3311 in favor of this version.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/peft/blob/main/PHILOSOPHY.md)?
- [x] This PR fixes typos in the docs.
- [ ] N/A — docstring-only typo fix.